### PR TITLE
Apache 2 licensing and attribution

### DIFF
--- a/MagicLanternHubitatDTH/magic-lantern.groovy
+++ b/MagicLanternHubitatDTH/magic-lantern.groovy
@@ -1,10 +1,21 @@
 /**
- *  MagicLantern
- *
- *  Author:
- *    Joshua Marker - joshua@nowhereville.org - @tooluser
- *
- */
+*  MagicLantern
+*
+*  Author:
+*    Joshua Marker - joshua@nowhereville.org - @tooluser
+*
+*  Code partially based on Adam Kempenich's Hubitat MagicHome Drivers. https://github.com/adamkempenich/hubitat
+*
+*  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License. You may obtain a copy of the License at:
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+*  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+*  for the specific language governing permissions and limitations under the License.
+*
+*/
 
 import hubitat.helper.HexUtils
 import hubitat.device.HubAction


### PR DESCRIPTION
Hi Joshua! I was scrolling Github looking for Hue driver, and while scrolling, I noticed that you're using some of my MagicHome code in your project verbatim to my original writing in your project. 

This is fine—and it's completely fair game to use—but it's licensed under Apache 2 and requires attribution. Specifically, the imports, logDebug preferences and method,  deviceIP preferences, parts of your commands ( '// 0 - 255' ), and parse, are verbatim to my original code.

It looks like this is the only file affected, so I've made a PR with attribution added in hopes that you'll work with me in honoring the Apache 2 license listed in my drivers.